### PR TITLE
Reduce image size

### DIFF
--- a/DockerExporter.csproj
+++ b/DockerExporter.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>docker_exporter</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <PublishTrimmed>true</PublishTrimmed>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-alpine AS build
 WORKDIR /app
 
 # Separate layers here to avoid redoing dependencies on code change.
@@ -8,10 +8,10 @@ RUN dotnet restore
 
 # Now the code.
 COPY . .
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -r linux-musl-x64 -c Release -o out
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS runtime
+FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-alpine AS runtime
 WORKDIR /app
 COPY --from=build /app/out .
 
-ENTRYPOINT ["dotnet", "docker_exporter.dll"]
+ENTRYPOINT ["./docker_exporter"]


### PR DESCRIPTION
Uses an Alpine version of the SDK builder image to compile a self-contained, trimmed assembly that runs on the minimal .NET Core base image. This brings the final uncompressed image size from 208MB down to 57MB.

While I haven't tested it thoroughly, it appears to produce metrics just fine.