### PR TITLE
ArgumentNullException when other containers restart

### DIFF
--- a/ContainerTracker.cs
+++ b/ContainerTracker.cs
@@ -187,16 +187,16 @@ namespace DockerExporter
             }
             else
             {
-                var readEntries = resources.BlkioStats.IoServiceBytesRecursive
+                var readEntries = resources.BlkioStats.IoServiceBytesRecursive?
                     .Where(entry => entry.Op.Equals("read", StringComparison.InvariantCultureIgnoreCase))
                     .ToArray();
 
-                var writeEntries = resources.BlkioStats.IoServiceBytesRecursive
+                var writeEntries = resources.BlkioStats.IoServiceBytesRecursive?
                     .Where(entry => entry.Op.Equals("write", StringComparison.InvariantCultureIgnoreCase))
                     .ToArray();
 
-                var totalRead = readEntries.Any() ? readEntries.Sum(entry => (long)entry.Value) : 0;
-                var totalWrite = writeEntries.Any() ? writeEntries.Sum(entry => (long)entry.Value) : 0;
+                var totalRead = readEntries == null ? 0 : readEntries.Any() ? readEntries.Sum(entry => (long)entry.Value) : 0;
+                var totalWrite = writeEntries == null ? 0 : writeEntries.Any() ? writeEntries.Sum(entry => (long)entry.Value) : 0;
 
                 metrics.TotalDiskBytesRead.Set(totalRead);
                 metrics.TotalDiskBytesWrite.Set(totalWrite);


### PR DESCRIPTION
Docker exporter crashes with a `ArgumentNullException` (caused by `resources.BlkioStats.IoServiceBytesRecursive` being null) when being scraped by Prometheus while other containers on the same host are crashing and constantly being restarted by Docker as they were run with the `--restart=always` flag.

#### Steps to reproduce crash:

1. Build and run docker exporter:

   ```
   docker build -t docker_exporter .
   docker run --name docker_exporter --detach --volume "/var/run/docker.sock":"/var/run/docker.sock" --publish 9417:9417 docker_exporter
   ```
1. Setup Prometheus to keep scraping from it.
1. Start another container which keeps crashing and restarting.

   ```
   docker run -d --restart=always --name test-crash-server --entrypoint sh nginx:latest kill
   ```

After a while, docker exporter would crash with a log like this:

```
Error   2020-02-20 09:56:40Z [] Value cannot be null. (Parameter 'source') (ArgumentNullException)
Error   2020-02-20 09:56:40Z [] System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at System.Linq.ThrowHelper.ThrowArgumentNullException(ExceptionArgument argument)
   at System.Linq.Enumerable.Where[TSource](IEnumerable`1 source, Func`2 predicate)
   at DockerExporter.ContainerTracker.UpdateResourceMetrics(ContainerTrackerResourceMetrics metrics, ContainerInspectResponse container, ContainerStatsResponse resources)
   at DockerExporter.ContainerTracker.TryUpdateAsync(DockerClient client, CancellationToken cancel)
   at DockerExporter.DockerTracker.TryUpdateAsync()
   at Axinom.Toolkit.ExtensionsForTask.WaitAndUnwrapExceptions(Task task)
   at Axinom.Toolkit.ExtensionsForTask.<>c.<WithAbandonment>b__10_0(Task completedTask)
   at System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__274_0(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
--- End of stack trace from previous location where exception was thrown ---
```